### PR TITLE
Remove redundant permission denial messages from Whisper commands

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -30,7 +30,6 @@ def audio_processing(message):
     Replies to sender with audio transcription.
     '''
     if not whisper_allowed(message):
-        bot.reply_to(message, "No tienes permiso para usar Whisper.")
         return
     audio2text.transcribe(message)
 
@@ -47,15 +46,11 @@ def echo_all(message):
     elif (message.text[1:] in MODEL_TYPES):
         if whisper_allowed(message):
             answer = audio2text.load_model(message, message.text[1:])
-        else:
-            answer = "No tienes permiso para usar Whisper."
     elif (message.text in ["/modelo", "/model"]):
         answer = "El modelo de Whisper en uso es " + audio2text.type
     elif (message.text[:4] == "http"):
         if whisper_allowed(message):
             answer = audio2text.transcribe(message)
-        else:
-            answer = "No tienes permiso para usar Whisper."
 
     if answer is not None:
         bot.reply_to(message, answer, parse_mode='Markdown')

--- a/src/main.py
+++ b/src/main.py
@@ -29,9 +29,8 @@ def audio_processing(message):
     Gets a message with audio.
     Replies to sender with audio transcription.
     '''
-    if not whisper_allowed(message):
-        return
-    audio2text.transcribe(message)
+    if whisper_allowed(message):
+        audio2text.transcribe(message)
 
 @bot.message_handler(func=lambda msg: True)
 def echo_all(message):


### PR DESCRIPTION
## Summary
This PR removes redundant permission denial messages that were being sent to users when they lacked permission to use Whisper features. The permission checks remain in place, but the error messages are no longer returned to the user.

## Key Changes
- Removed the permission denial reply in `audio_processing()` when `whisper_allowed()` returns False
- Removed the permission denial message assignment in `echo_all()` for model loading when user lacks permission
- Removed the permission denial message assignment in `echo_all()` for URL transcription when user lacks permission

## Implementation Details
The permission checks (`whisper_allowed()`) are still being performed, but instead of sending an error message back to the user, the function now silently returns without executing the restricted operation. This appears to be a deliberate change in UX behavior, possibly to reduce noise or change how permission denials are communicated to users.

https://claude.ai/code/session_01WycfE8NFRPDBD1YkRnCVVe